### PR TITLE
Use extracted port value for IPv6 connection as well

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -582,7 +582,7 @@ pub async fn lookup_server<P: ConnectionProvider>(
                 for addr in ipv6.record_iter() {
                     if let Some(ip) = addr.data().as_aaaa() {
                         addrs.push(ip.0.to_string());
-                        addrs_with_port.push(format!("[{}]:443", ip.0));
+                        addrs_with_port.push(format!("[{}]:{port}", ip.0));
                     }
                 }
             }


### PR DESCRIPTION
Without this, IPv6 connections are always attempted on port `443`, regardless of what the extracted port value was (e.g. `8448`).

This used to cause servers that support IPv6 to be reported as not fully OK.