### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,24 +31,24 @@ The service will listen on `0.0.0.0:8080` by default.
 
 ### API Endpoints
 
-#### `GET /api/report?server_name=<server_name>&no_cache=<true|false>`
+#### `GET /api/federation/report?server_name=<server_name>&no_cache=<true|false>`
 
 Returns a detailed JSON report about the federation status of the given server.
 
 **Example:**
 
 ```text
-GET /api/report?server_name=matrix.org
+GET /api/federation/report?server_name=matrix.org
 ```
 
-#### `GET /api/federation-ok?server_name=<server_name>&no_cache=<true|false>`
+#### `GET /api/federation/federation-ok?server_name=<server_name>&no_cache=<true|false>`
 
 Returns `GOOD` if federation is OK, otherwise `BAD`.
 
 **Example:**
 
 ```text
-GET /api/federation-ok?server_name=matrix.org
+GET /api/federation/federation-ok?server_name=matrix.org
 ```
 
 ## Test & Coverage

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -539,7 +539,7 @@ pub fn load_config() -> Result<AppConfig, ConfigError> {
 
     if app.magic_token_secret.len() < 32 {
         return Err(ConfigError::Validation(
-            "magic_token_secret must be at least 16 characters".into(),
+            "magic_token_secret must be at least 32 characters".into(),
         ));
     }
 


### PR DESCRIPTION
* Error message claims `magic_secret_token` must be 16 chars long, but it's 32 instead.
* Fix API endpoints in docs