### PR TITLE
server: load CAs from system store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4757,6 +4757,7 @@ dependencies = [
  "redis",
  "reqwest 0.13.3",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "rustls-webpki",
  "sea-orm",
@@ -4783,7 +4784,6 @@ dependencies = [
  "utoipa-axum",
  "utoipa-redoc",
  "uuid",
- "webpki-roots 1.0.7",
  "wiremock",
  "x509-parser",
 ]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -101,9 +101,9 @@ utoipa = { version = "5.4.0", features = [
 utoipa-axum = "0.2.0"
 utoipa-redoc = { version = "6.0.0", features = ["axum"] }
 uuid = "1.17.0"
-webpki-roots = "1.0"
 x509-parser = "0.18"
 pulldown-cmark = "0.13.3"
+rustls-native-certs = "0.8.3"
 
 [dev-dependencies]
 axum-test = "20.0.0"

--- a/crates/server/src/optimization.rs
+++ b/crates/server/src/optimization.rs
@@ -18,7 +18,11 @@ pub fn get_shared_tls_config() -> Arc<ClientConfig> {
     TLS_CONFIG
         .get_or_init(|| {
             let mut root_cert_store = RootCertStore::empty();
-            root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            for cert in
+                rustls_native_certs::load_native_certs().expect("could not load platform certs")
+            {
+                root_cert_store.add(cert).unwrap();
+            }
 
             let config = ClientConfig::builder()
                 .with_root_certificates(root_cert_store)


### PR DESCRIPTION
The primary use-case is to be able to use this software for integration tests verifying the functionality of synapse packages in NixOS where federation between two VMs is tested. Both VMs have a cert signed by a mock CA that's in the trust store of these VMs. This patch allows this federation tester to work with it.

Generally I think it's more wise to have software load the system store anyways: it's way easier to update a single store per node rather than identifying all the deployed software that happens to somehow load its own CA from somewhere.

cc @MTRNord @networkexception